### PR TITLE
Testing

### DIFF
--- a/GMRScripts/normalise_csv.py
+++ b/GMRScripts/normalise_csv.py
@@ -6,15 +6,15 @@ import GMRScripts.organisation_functions as org
 from shutil import copy
 
 
-def ReadInPwr(file_name):
+def ReadInPwr(dir_name):
     '''
     Read in and process the power spectrum data file
     Args:
         file_name, string file path
     '''
-    pwr_spec = os.path.join(file_name, 'power_spectrum.csv')
+    pwr_spec = os.path.join(dir_name, 'power_spectrum.csv')
     step, wl, f, power = np.genfromtxt(pwr_spec,
-                                       delimiter=',',
+                                       delimiter='\t',
                                        skip_header=1,
                                        unpack=True)
     max_element = np.amax(power)
@@ -81,7 +81,7 @@ def PlotCorrectedImage(file_name,
     Plot a raw image and corrected image (calculate brightness
     values from pixels mean/std) save corrected image out
     '''
-    corrected_img_dir = img_dir
+    corrected_img_dir = os.path.join(img_dir, 'corrected_imgs')
     corrected_img_dir_pngs = f'{corrected_img_dir}_pngs'
 
     file, img_no = Filename(file_name).split('_')

--- a/GMRScripts/organisation_functions.py
+++ b/GMRScripts/organisation_functions.py
@@ -5,34 +5,6 @@ import numpy as np
 from shutil import copy
 
 
-def Platform():
-    '''
-    Determines the directory path based on which operating system the user is
-    using. This is only relevant if you use two different operating systems.
-    Returns main directory as a path.
-    Args:
-        No required args but does require user input to determine the directory
-        path you wish to use.
-    '''
-    if platform.system() == 'Windows':
-        os.system('cls')
-        main_dir = os.path.join('C:/'
-                                'Users',
-                                'joshs',
-                                'Documents',
-                                'Masters_Project')
-
-    if platform.system() == 'Linux' or platform.system() == 'Darwin':
-        os.system('clear')
-        main_dir = os.path.join('media',
-                                'mass_storage',
-                                'josh',
-                                'Documents',
-                                'Masters_Project')
-
-    return main_dir
-
-
 def FileSort(dir_name):
     '''
     Numerically sort a directory containing a combination of string file names

--- a/normalise.py
+++ b/normalise.py
@@ -1,28 +1,35 @@
 import os
 import GMRScripts.organisation_functions as org
 import GMRScripts.normalise_csv as ncsv
+import GMRScripts.config_dirpath as con
 
-main_dir = org.Platform()
-sub_dir = os.path.join(main_dir, '220319_to_120419', '100419')
-img_dir = os.path.join(sub_dir, 'test')
-corrected_img_dir = os.path.join(img_dir, 'corrected_imgs')
-corrected_img_dir_pngs = os.path.join(img_dir, 'corrected_imgs_pngs')
-pixel_stack_dir = os.path.join(img_dir, 'pixel_stack')
-pixel_stack_dir_pngs = os.path.join(img_dir, 'pixel_stack_pngs')
+main_dir = con.ConfigDirPath()
+'''
+Platform is kind of an irrelevant function now if we want to just have
+a directory where users 'dump' their data.
+'''
+data_dirs = os.listdir(main_dir)
+'''
+This allows for users to place data directories from GMRX in to the
+put_data_here directory.
+'''
+for directory in data_dirs:
+    img_dir = os.path.join(main_dir, directory)
+    
+    data_files = org.ExtractFiles(dir_name=img_dir, file_string='img_')
 
-data_files = org.ExtractFiles(dir_name=img_dir, file_string='img_')
-in_file = os.path.join(img_dir, 'power_spectrum.csv')
+    step, wl, f, power, norm_power = ncsv.ReadInPwr(dir_name=img_dir)
 
-step, wl, f, power, norm_power = ncsv.ReadInPwr(in_file)
+    ncsv.PlotDouble(wl, power, norm_power, show=False)
 
-ncsv.PlotDouble(wl, power, norm_power, show=False)
+    for index, file in enumerate(data_files):
+        file_name = os.path.join(img_dir, file)
+        ncsv.PlotCorrectedImage(file_name,
+                                f'corrected_{file[0:-4]}',
+                                img_dir,
+                                norm_power,
+                                save_out=True,
+                                plot_show=False,
+                                plot_save=True)
 
-for index, file in enumerate(data_files):
-    file_name = os.path.join(img_dir, file)
-    ncsv.PlotCorrectedImage(file_name,
-                            f'corrected_{file[0:-4]}',
-                            save_out=True,
-                            plot_show=False,
-                            plot_save=False)
-
-    org.UpdateProgress((index + 1) / len(data_files))
+        org.UpdateProgress((index + 1) / len(data_files))

--- a/normalise.py
+++ b/normalise.py
@@ -4,15 +4,8 @@ import GMRScripts.normalise_csv as ncsv
 import GMRScripts.config_dirpath as con
 
 main_dir = con.ConfigDirPath()
-'''
-Platform is kind of an irrelevant function now if we want to just have
-a directory where users 'dump' their data.
-'''
 data_dirs = os.listdir(main_dir)
-'''
-This allows for users to place data directories from GMRX in to the
-put_data_here directory.
-'''
+
 for directory in data_dirs:
     img_dir = os.path.join(main_dir, directory)
 

--- a/normalise.py
+++ b/normalise.py
@@ -15,7 +15,7 @@ put_data_here directory.
 '''
 for directory in data_dirs:
     img_dir = os.path.join(main_dir, directory)
-    
+
     data_files = org.ExtractFiles(dir_name=img_dir, file_string='img_')
 
     step, wl, f, power, norm_power = ncsv.ReadInPwr(dir_name=img_dir)
@@ -30,6 +30,6 @@ for directory in data_dirs:
                                 norm_power,
                                 save_out=True,
                                 plot_show=False,
-                                plot_save=True)
+                                plot_save=False)
 
         org.UpdateProgress((index + 1) / len(data_files))


### PR DESCRIPTION
No need to still be using Platform function if we want people to be place all their data into one folder. Used ConfigDirPath function instead.
ReadInPwr function was being fed an in_file which meant it was looking for img_dir/power_spectrum.csv/power_spectrum.csv so this in_file has been removed and now the ReadInPwr function is just fed the img_dir and looks for the power_spectrum.csv file within the function. If this is a standard name from GMRX software then it can be left in the function and only needs changing when the software changes the output.
Img_dir and norm_power were required for PlotCorrectedImage but not actually being called forward by the function, they have been added.
Platform as a function has been removed entirely from the organisation_functions.py file - no longer necessary.